### PR TITLE
Make it compile again

### DIFF
--- a/selinux/nodejs.te
+++ b/selinux/nodejs.te
@@ -14,6 +14,13 @@ type nodejs_port_t;
 type nodejs_log_t;
 logging_log_file(nodejs_log_t);
 
+require {
+        type net_conf_t;
+        type httpd_sys_content_t;
+        type node_t;
+        type ntop_port_t;
+}
+
 ########################################
 #
 # nodejs local policy


### PR DESCRIPTION
Hi there,

your nodejs module does not compile anymore.  The output looks like this:

```bash
root@selinux:~/node-systemd-selinux/selinux$ ./nodejs.sh 
Building and Loading Policy
+ make -f /usr/share/selinux/devel/Makefile nodejs.pp
Compiling targeted nodejs module
/usr/bin/checkmodule:  loading policy configuration from tmp/nodejs.tmp
nodejs.te:30:ERROR 'unknown type net_conf_t' at token ';' on line 3713:
allow nodejs_t self:tcp_socket { { { create { ioctl read getattr lock write setattr append bind connect getopt setopt shutdown } } listen accept } name_bind };
allow nodejs_t net_conf_t:file { read getattr open };
/usr/bin/checkmodule:  error(s) encountered while parsing configuration
make: *** [tmp/nodejs.mod] Fehler 1
+ exit
```

The changes in this pull request add the needed require section to the .te file, therefore allowing it to compile properly.

Regards.